### PR TITLE
typo fix in the def'n of RSS for linear regression

### DIFF
--- a/data_science_cheatsheet.tex
+++ b/data_science_cheatsheet.tex
@@ -536,7 +536,7 @@
     	$Y \approx \beta_{0} + \beta_{1}X_{1} + ... + \beta_{p}X_{p} + \epsilon$
     \end{center}
     
-    $\beta_{0}...\beta_{p}$ are the unknown coefficients (parameters) which we are trying to determine. The best coefficients will lead us to the best "fit", which can be found by minimizing the \textit{residual sum squares} (RSS), or the sum of the differences between the actual $i$th value and the predicted $i$th value. RSS = $\sum_{i=1}^{n} e_{i}$, where $e_{i} = y_{i} - \hat{y_{i}}$\\
+    $\beta_{0}...\beta_{p}$ are the unknown coefficients (parameters) which we are trying to determine. The best coefficients will lead us to the best "fit", which can be found by minimizing the \textit{residual sum squares} (RSS), or the sum of the squared differences between the actual $i$th value and the predicted $i$th value. RSS = $\sum_{i=1}^{n} e_{i}^2$, where $e_{i} = y_{i} - \hat{y_{i}}$\\
     
 %     \begin{center}
     


### PR DESCRIPTION
Expression was missing a squared superscript.